### PR TITLE
Fix chain_test.js

### DIFF
--- a/childchain/test/chain_test.js
+++ b/childchain/test/chain_test.js
@@ -16,7 +16,6 @@ describe('Chain', function() {
         metadb: memdown(),
         snapshotdb: memdown()
       }).then(chain=>{
-        Listener.run(chain);
         const initialBlockHeight = chain.blockHeight;
 
         chain.applyDeposit({
@@ -42,8 +41,6 @@ describe('Chain', function() {
         metadb: memdown(),
         snapshotdb: memdown()
       }).then(chain=>{
-        Listener.run(chain);
-
         chain.applyDeposit({
           returnValues: {
             depositor: depositor,


### PR DESCRIPTION
## Description

We don't need `Listener` for these two specs.

We should provide RootChain mock if we use `Listener` in specs.

```
(node:80661) UnhandledPromiseRejectionWarning: Error: Provider not set or invalid
    at Object.InvalidProvider (/Users/syuhei/work/ethstacks/node_modules/web3-core-helpers/src/errors.js:38:16)
    at RequestManager.send (/Users/syuhei/work/ethstacks/node_modules/web3-core-requestmanager/src/index.js:128:32)
    at sendRequest (/Users/syuhei/work/ethstacks/node_modules/web3-core-method/src/index.js:560:42)
    at Eth.send [as getBlock] (/Users/syuhei/work/ethstacks/node_modules/web3-core-method/src/index.js:581:13)
    at RootChainEventListener.getEvents (/Users/syuhei/work/ethstacks/listener/lib/index.js:15:34)
    at Object.module.exports.run.childChain [as run] (/Users/syuhei/work/ethstacks/listener/lib/index.js:63:26)
    at chainManager.start.then.chain (/Users/syuhei/work/ethstacks/childchain/test/chain_test.js:53:18)
```
