### PR TITLE
Add publish all packages script

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.0.5"
+  "version": "1.0.6"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.0.0"
+  "version": "1.0.5"
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "node main",
     "run-all": "yarn run wsrun",
     "build": "lerna run build",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "publish": "yarn build && lerna publish"
   },
   "repository": {
     "type": "git",

--- a/packages/chamber-childchain/package.json
+++ b/packages/chamber-childchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptoeconomicslab/chamber-childchain",
-  "version": "0.0.10",
+  "version": "1.0.6",
   "description": "",
   "main": "lib/index.js",
   "publishConfig": {
@@ -13,10 +13,10 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@cryptoeconomicslab/chamber-listener": "^1.0.0"
+    "@cryptoeconomicslab/chamber-listener": "^1.0.6"
   },
   "dependencies": {
-    "@cryptoeconomicslab/chamber-core": "^1.0.0",
+    "@cryptoeconomicslab/chamber-core": "^1.0.6",
     "bignumber.js": "^8.0.1",
     "ethereumjs-util": "^5.2.0",
     "istanbul-coveralls": "^1.0.3",

--- a/packages/chamber-childchain/package.json
+++ b/packages/chamber-childchain/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.10",
   "description": "",
   "main": "lib/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "mocha",
     "cover": "istanbul cover _mocha && istanbul-coveralls"

--- a/packages/chamber-cli/package.json
+++ b/packages/chamber-cli/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "Plasma Chamber CLI",
   "main": "lib/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "chamber-cli": "src/index.js"
   },

--- a/packages/chamber-cli/package.json
+++ b/packages/chamber-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptoeconomicslab/plasma-chamber-cli",
-  "version": "0.0.1",
+  "version": "1.0.6",
   "description": "Plasma Chamber CLI",
   "main": "lib/index.js",
   "publishConfig": {
@@ -15,8 +15,8 @@
   "author": "CryptoEconomicsLab",
   "license": "MIT",
   "dependencies": {
-    "@cryptoeconomicslab/chamber-childchain": "^0.0.10",
-    "@cryptoeconomicslab/chamber-core": "^1.0.0",
+    "@cryptoeconomicslab/chamber-childchain": "^1.0.6",
+    "@cryptoeconomicslab/chamber-core": "^1.0.6",
     "bip39": "^2.5.0",
     "commander": "^2.18.0",
     "ethereumjs-wallet": "^0.6.2",

--- a/packages/chamber-core/package.json
+++ b/packages/chamber-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptoeconomicslab/chamber-core",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "index.js",
   "publishConfig": {

--- a/packages/chamber-core/package.json
+++ b/packages/chamber-core/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.5",
   "description": "",
   "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "mocha",
     "build": "babel src -d lib"

--- a/packages/chamber-lang/package.json
+++ b/packages/chamber-lang/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "chamber-lang",
+  "name": "@cryptoeconomicslab/chamber-lang",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "private": true,
   "scripts": {
     "test": "mocha"
   },

--- a/packages/chamber-lang/package.json
+++ b/packages/chamber-lang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptoeconomicslab/chamber-lang",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "description": "",
   "main": "index.js",
   "private": true,
@@ -10,9 +10,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cryptoeconomicslab/chamber-childchain": "^0.0.10",
-    "@cryptoeconomicslab/chamber-core": "^1.0.0",
-    "@cryptoeconomicslab/chamber-listener": "^1.0.0",
+    "@cryptoeconomicslab/chamber-childchain": "^1.0.6",
+    "@cryptoeconomicslab/chamber-core": "^1.0.6",
+    "@cryptoeconomicslab/chamber-listener": "^1.0.6",
     "ejs": "^2.6.1",
     "pegjs": "^0.10.0",
     "pegjs-prolog-parser": "^1.1.1"

--- a/packages/chamber-listener/package.json
+++ b/packages/chamber-listener/package.json
@@ -2,6 +2,7 @@
   "name": "@cryptoeconomicslab/chamber-listener",
   "version": "1.0.0",
   "description": "",
+  "private": true,
   "main": "lib/index.js",
   "directories": {
     "lib": "lib"

--- a/packages/chamber-listener/package.json
+++ b/packages/chamber-listener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptoeconomicslab/chamber-listener",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "description": "",
   "private": true,
   "main": "lib/index.js",

--- a/packages/chamber-rootchain/package.json
+++ b/packages/chamber-rootchain/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "chamber-rootchain",
+  "name": "@cryptoeconomicslab/chamber-rootchain",
   "version": "1.0.0",
   "description": "",
+  "private": true,
   "main": "index.js",
   "scripts": {
     "test": "export MODULE_RELATIVE_PATH=../ && truffle test"

--- a/packages/chamber-rootchain/package.json
+++ b/packages/chamber-rootchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptoeconomicslab/chamber-rootchain",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "description": "",
   "private": true,
   "main": "index.js",
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cryptoeconomicslab/chamber-childchain": "^0.0.10",
-    "@cryptoeconomicslab/chamber-core": "^1.0.0",
+    "@cryptoeconomicslab/chamber-childchain": "^1.0.6",
+    "@cryptoeconomicslab/chamber-core": "^1.0.6",
     "babel-runtime": "^6.26.0",
     "ethereumjs-tx": "^1.3.7",
     "ethereumjs-util": "^5.2.0",

--- a/packages/chamber-rpc/package.json
+++ b/packages/chamber-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptoeconomicslab/chamber-rpc",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "description": "",
   "private": true,
   "main": "lib/index.js",
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cryptoeconomicslab/chamber-listener": "^1.0.0",
+    "@cryptoeconomicslab/chamber-listener": "^1.0.6",
     "body-parser": "^1.18.3",
     "connect": "^3.6.6",
     "cors": "^2.8.4",

--- a/packages/chamber-rpc/package.json
+++ b/packages/chamber-rpc/package.json
@@ -2,6 +2,7 @@
   "name": "@cryptoeconomicslab/chamber-rpc",
   "version": "1.0.0",
   "description": "",
+  "private": true,
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",

--- a/packages/chamber-vm/package.json
+++ b/packages/chamber-vm/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "chamber-vm",
+  "name": "@cryptoeconomicslab/chamber-vm",
   "version": "1.0.0",
   "description": "",
+  "private": true,
   "main": "lib/index.js",
   "scripts": {
     "test": "istanbul cover --print both _mocha && istanbul-coveralls"

--- a/packages/chamber-vm/package.json
+++ b/packages/chamber-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptoeconomicslab/chamber-vm",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "description": "",
   "private": true,
   "main": "lib/index.js",


### PR DESCRIPTION
```
computer:/work $ yarn run publish
yarn run v1.9.4
$ yarn build && lerna publish
$ lerna run build
lerna notice cli v3.4.3
lerna info Executing command in 1 package: "yarn run build"
$ babel src -d lib
Successfully compiled 9 files with Babel.
lerna success run Ran npm script 'build' in 1 package:
lerna success - @cryptoeconomicslab/chamber-core
lerna notice cli v3.4.3
lerna WARN Yarn's registry proxy is broken, replacing with public npm registry
lerna WARN If you don't have an npm token, you should exit and run `npm login`
lerna info Verifying npm credentials
lerna http fetch GET 200 https://registry.npmjs.org/-/whoami 966ms
lerna info current version 1.0.5
lerna info Looking for changed packages since initial commit.
? Select a new version (currently 1.0.5) Patch (1.0.6)

Changes:
 - @cryptoeconomicslab/chamber-childchain: 0.0.10 => 1.0.6
 - @cryptoeconomicslab/plasma-chamber-cli: 0.0.1 => 1.0.6
 - @cryptoeconomicslab/chamber-core: 1.0.5 => 1.0.6
 - @cryptoeconomicslab/chamber-lang: 1.0.0 => 1.0.6 (private)
 - @cryptoeconomicslab/chamber-listener: 1.0.0 => 1.0.6 (private)
 - @cryptoeconomicslab/chamber-rootchain: 1.0.0 => 1.0.6 (private)
 - @cryptoeconomicslab/chamber-rpc: 1.0.0 => 1.0.6 (private)
 - @cryptoeconomicslab/chamber-vm: 1.0.0 => 1.0.6 (private)
```