### PR TITLE
Separate strategy from wallet.ts and add specs for them #302

### DIFF
--- a/packages/wallet/src/strategy/defrag.ts
+++ b/packages/wallet/src/strategy/defrag.ts
@@ -1,0 +1,93 @@
+import {
+  Segment,
+  SignedTransactionWithProof,
+  StateUpdate,
+  SwapRequest,
+  OwnershipPredicate,
+  Address
+} from '@layer2/core'
+import { BigNumber } from 'ethers/utils'
+
+export class DefragAlgorithm {
+
+  /**
+   * searchMergable search mergable stateUpdates
+   * @param targetBlockNumber is target block number
+   */
+  static searchMergable(
+    utxos: SignedTransactionWithProof[],
+    targetBlockNumber: BigNumber,
+    ownershipPredicate: string,
+    myAddress: Address
+  ): StateUpdate | null {
+    let tx = null
+    let segmentEndMap = new Map<string, SignedTransactionWithProof>()
+    utxos.forEach((_tx) => {
+      const segment = _tx.getOutput().getSegment()
+      const start = segment.start.toString()
+      const end = segment.end.toString()
+      const tx2 = segmentEndMap.get(start)
+      if(tx2) {
+        // _tx and segmentStartMap.get(start) are available for merge transaction
+        tx = OwnershipPredicate.create(
+          _tx.getOutput().getSegment().add(tx2.getOutput().getSegment()),
+          targetBlockNumber,
+          ownershipPredicate,
+          myAddress
+        )
+      }
+      segmentEndMap.set(end, _tx)
+    })
+    return tx
+  }
+
+  /**
+   * make swap request to open channel
+   * @param utxos
+   */
+  static makeSwapRequest(
+    utxos: SignedTransactionWithProof[]
+  ): SwapRequest | null {
+    let swapRequest = null
+    utxos.forEach((txNeighbor) => {
+      const neighbor = txNeighbor.getOutput().getSegment()
+      const txs = DefragAlgorithm.searchHole(utxos, neighbor)
+      if(txs.length > 0) {
+        const output = txs[0].getOutput()
+        swapRequest = new SwapRequest(
+          output.getOwner(),
+          output.getBlkNum(),
+          output.getSegment(),
+          txNeighbor.getOutput().getBlkNum(),
+          neighbor)
+      }
+    })
+    return swapRequest
+  }
+  
+  /**
+   * search UTXOs which have holes between them and neighbor
+   * @param utxos 
+   * @param neighbor 
+   */
+  private static searchHole(
+    utxos: SignedTransactionWithProof[],
+    neighbor: Segment
+  ): SignedTransactionWithProof[] {
+    return utxos.filter((_tx) => {
+      const segment = _tx.getOutput().getSegment()
+      return neighbor.end.lt(segment.start)
+    })
+  }
+
+  static searchNeighbors(
+    utxos: SignedTransactionWithProof[],
+    swapRequest: SwapRequest
+  ): StateUpdate[] {
+    return utxos.filter((_tx) => {
+      const segment = _tx.getOutput().getSegment()
+      return swapRequest.check(segment)
+    }).map(s => s.getOutput())
+  }
+
+}

--- a/packages/wallet/src/strategy/transfer.ts
+++ b/packages/wallet/src/strategy/transfer.ts
@@ -1,0 +1,54 @@
+import {
+  Segment,
+  SignedTransaction,
+  SignedTransactionWithProof,
+  StateUpdate,
+  OwnershipPredicate,
+  Address
+} from '@layer2/core'
+import { utils } from 'ethers'
+import BigNumber = utils.BigNumber
+
+export class TransferAlgorithm {
+
+  static searchUtxo(
+    utxos: SignedTransactionWithProof[],
+    targetBlockNumber: number,
+    ownershipPredicate: string,
+    to: Address,
+    tokenId: number,
+    amount: BigNumber,
+    feeTo?: Address,
+    fee?: BigNumber
+  ): SignedTransaction | null {
+    let tx: SignedTransaction | null = null
+    const targetBlock = utils.bigNumberify(targetBlockNumber)
+    utxos
+    .filter(_tx => _tx.getOutput().getSegment().getTokenId().eq(tokenId))
+    .forEach((_tx) => {
+      const output = _tx.getOutput()
+      const segment = output.getSegment()
+      const sum = amount.add(fee || 0)
+      if(segment.getAmount().gte(sum)) {
+        const paymentTx = OwnershipPredicate.create(
+          new Segment(segment.getTokenId(), segment.start, segment.start.add(amount)),
+          targetBlock,
+          ownershipPredicate,
+          to)
+        if(feeTo && fee) {
+          const feeStart = segment.start.add(amount)
+          const feeTx = OwnershipPredicate.create(
+            new Segment(segment.getTokenId(), feeStart, feeStart.add(fee)),
+            targetBlock,
+            ownershipPredicate,
+            feeTo)
+          tx = new SignedTransaction([paymentTx, feeTx])
+        } else {
+          tx = new SignedTransaction([paymentTx])
+        }
+      }
+    })
+    return tx
+  }
+
+}

--- a/packages/wallet/test/DefragAlgoritm.test.ts
+++ b/packages/wallet/test/DefragAlgoritm.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "mocha"
+import {
+  DefragAlgorithm
+} from '../src/strategy/defrag'
+import { Block, PredicatesManager, Segment } from "@layer2/core"
+import { assert } from "chai"
+import { createTransfer, AlicePrivateKey, BobPrivateKey } from './TestUtil'
+import { constants, utils } from "ethers"
+
+describe('DefragAlgorithm', () => {
+
+  const AliceAddress = utils.computeAddress(AlicePrivateKey)
+  const predicate = constants.AddressZero
+  const predicateManager = new PredicatesManager()
+  predicateManager.addPredicate(predicate, 'OwnershipPredicate')
+  const segment1 = Segment.ETH(utils.bigNumberify(0), utils.bigNumberify(1000000))
+  const segment2 = Segment.ETH(utils.bigNumberify(1000000), utils.bigNumberify(2000000))
+  const segment3 = Segment.ETH(utils.bigNumberify(2000000), utils.bigNumberify(3000000))
+  const blkNum4 = utils.bigNumberify(4)
+  const block6 = new Block(6)
+  block6.setBlockNumber(6)
+  const block8 = new Block(8)
+  block8.setBlockNumber(8)
+  const tx1 = createTransfer(BobPrivateKey, predicate, segment1, blkNum4, AliceAddress)
+  const tx2 = createTransfer(BobPrivateKey, predicate, segment2, blkNum4, AliceAddress)
+  const tx3 = createTransfer(BobPrivateKey, predicate, segment3, blkNum4, AliceAddress)
+  block6.appendTx(tx1)
+  block6.appendTx(tx2)
+  block6.appendTx(tx3)
+  block6.setSuperRoot(constants.HashZero)
+
+  beforeEach(() => {
+  })
+
+  it('searchMergable', async () => {
+    const signedTx1 = block6.getSignedTransactionWithProof(tx1.hash())[0]
+    const signedTx2 = block6.getSignedTransactionWithProof(tx2.hash())[0]
+    const signedTx3 = block6.getSignedTransactionWithProof(tx3.hash())[0]
+    const mergable = DefragAlgorithm.searchMergable([signedTx1, signedTx2, signedTx3], utils.bigNumberify(10), predicate, AliceAddress)
+    assert.isNotNull(mergable)
+    if(mergable) {
+      assert.equal(mergable.getSegment().start.toString(), segment2.start.toString())
+      assert.equal(mergable.getSegment().end.toString(), segment3.end.toString())
+    }
+  })
+
+  it('makeSwapRequest', async () => {
+    const signedTx1 = block6.getSignedTransactionWithProof(tx1.hash())[0]
+    const signedTx3 = block6.getSignedTransactionWithProof(tx3.hash())[0]
+    const swapRequest = DefragAlgorithm.makeSwapRequest(
+      [signedTx1, signedTx3])
+    assert.isNotNull(swapRequest)
+    if(swapRequest) {
+      assert.equal(swapRequest.segment.start.toString(), segment3.start.toString())
+      assert.equal(swapRequest.getNeighbor().start.toString(), segment1.start.toString())
+    }
+  })
+
+})

--- a/packages/wallet/test/TestUtil.ts
+++ b/packages/wallet/test/TestUtil.ts
@@ -1,0 +1,17 @@
+import { utils } from 'ethers'
+import BigNumber = utils.BigNumber
+import {
+  OwnershipPredicate,
+  Segment,
+  SignedTransaction
+} from "@layer2/core"
+
+export function createTransfer(privKey: string, predicate: string, seg: Segment, blkNum: BigNumber, to: string) {
+  const stateUpdate = OwnershipPredicate.create(seg, blkNum, predicate, to)
+  const tx= new SignedTransaction([stateUpdate])
+  tx.sign(privKey)
+  return tx
+}
+
+export const AlicePrivateKey = '0xe88e7cda6f7fae195d0dcda7ccb8d733b8e6bb9bd0bc4845e1093369b5dc2257'
+export const BobPrivateKey = '0xae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f'

--- a/packages/wallet/test/TransferAlgorithm.test.ts
+++ b/packages/wallet/test/TransferAlgorithm.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "mocha"
+import {
+  TransferAlgorithm
+} from '../src/strategy/transfer'
+import { Block, PredicatesManager, Segment } from "@layer2/core"
+import { assert } from "chai"
+import { createTransfer, AlicePrivateKey, BobPrivateKey } from './TestUtil'
+import { constants, utils } from "ethers"
+
+describe('TransferAlgorithm', () => {
+
+  const AliceAddress = utils.computeAddress(AlicePrivateKey)
+  const BobAddress = utils.computeAddress(BobPrivateKey)
+  const predicate = constants.AddressZero
+  const predicateManager = new PredicatesManager()
+  predicateManager.addPredicate(predicate, 'OwnershipPredicate')
+  const segment1 = Segment.ETH(utils.bigNumberify(0), utils.bigNumberify(1000000))
+  const segment2 = Segment.ETH(utils.bigNumberify(1000000), utils.bigNumberify(2000000))
+  const segment3 = Segment.ETH(utils.bigNumberify(2000000), utils.bigNumberify(3000000))
+  const blkNum4 = utils.bigNumberify(4)
+  const block6 = new Block(6)
+  block6.setBlockNumber(6)
+  const block8 = new Block(8)
+  block8.setBlockNumber(8)
+  const tx1 = createTransfer(BobPrivateKey, predicate, segment1, blkNum4, AliceAddress)
+  const tx2 = createTransfer(BobPrivateKey, predicate, segment2, blkNum4, AliceAddress)
+  const tx3 = createTransfer(BobPrivateKey, predicate, segment3, blkNum4, AliceAddress)
+  block6.appendTx(tx1)
+  block6.appendTx(tx2)
+  block6.appendTx(tx3)
+  block6.setSuperRoot(constants.HashZero)
+
+  beforeEach(() => {
+  })
+
+  it('searchUtxo', async () => {
+    const signedTx1 = block6.getSignedTransactionWithProof(tx1.hash())[0]
+    const signedTx2 = block6.getSignedTransactionWithProof(tx2.hash())[0]
+    const signedTx3 = block6.getSignedTransactionWithProof(tx3.hash())[0]
+    const transferTx = TransferAlgorithm.searchUtxo(
+      [signedTx1, signedTx2, signedTx3],
+      10,
+      predicate,
+      AliceAddress,
+      0,
+      utils.bigNumberify(100),
+      BobAddress,
+      utils.bigNumberify(10))
+    assert.isNotNull(transferTx)
+    if(transferTx) {
+      assert.equal(transferTx.getStateUpdate(0).getSegment().getAmount().toNumber(), 100)
+      const transferSegment = transferTx.getStateUpdate(0).getSegment()
+      assert.isTrue(segment3.isContain(transferSegment))
+    }
+  })
+
+})


### PR DESCRIPTION
## Purpose

* separate transfer and defragmentation logic from `wallet.ts`
* adding tests

## Description

I added strategy folder to separate algorithm of transfer logic and defragmentation.
And write specs for each function.
This is just refactoring.

related to #302
patch