### PR TITLE
Add sendTransaction API #327

### DIFF
--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -707,6 +707,13 @@ export class ChamberWallet extends EventEmitter {
     return fastTransferResponse
   }
 
+  async sendTransaction(
+    signedTx: SignedTransaction
+  ): Promise<ChamberResult<boolean>> {
+    signedTx.sign(this.wallet.privateKey)
+    return await this.client.sendTransaction(signedTx)
+  }
+
   async merge() {
     const targetBlock = ethers.utils.bigNumberify(this.getTargetBlockNumber())
     const tx = this.searchMergable(targetBlock)


### PR DESCRIPTION
## Description

Add raw API for sending SignedTransaction.

- Users should create SignedTransaction which has two stateUpdate(DexPredicate).
- Users should sign it and exchange in off chain.
- send transaction using `wallet.sendTransaction`
